### PR TITLE
chore: bump diagram-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "brfs": "^1.5.0",
     "browserify": "^16.1.1",
     "chai": "^4.1.2",
-    "diagram-js": "^6.0.1",
+    "diagram-js": "^7.2.0",
     "eslint": "^4.13.1",
     "eslint-plugin-bpmn-io": "^0.5.2",
     "jsondiffpatch": "^0.1.8",
@@ -46,6 +46,6 @@
     "watchify": "^3.9.0"
   },
   "peerDependencies": {
-    "diagram-js": "^0.x || ^1.x || ^2.x || ^3.x || ^4.x || ^5.x || ^6.x"
+    "diagram-js": "^0.x || ^1.x || ^2.x || ^3.x || ^4.x || ^5.x || ^6.x || ^7.x"
   }
 }


### PR DESCRIPTION
Increase peer-dependency to diagram-js@7 to avoid warnings via install.

Related to https://github.com/camunda/camunda-bpmn-js/issues/1