### PR TITLE
Update `tiny-svg`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
-        "tiny-svg": "^2.0.0"
+        "tiny-svg": "^3.0.0"
       },
       "devDependencies": {
         "babel-core": "^6.26.0",
@@ -2677,6 +2677,12 @@
         "path-intersection": "^2.2.1",
         "tiny-svg": "^2.2.2"
       }
+    },
+    "node_modules/diagram-js/node_modules/tiny-svg": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.4.tgz",
+      "integrity": "sha512-NOi39lBknf4UdDEahNkbEAJnzhu1ZcN2j75IS2vLRmIhsfxdZpTChfLKBcN1ShplVmPIXJAIafk6YY5/Aa80lQ==",
+      "dev": true
     },
     "node_modules/didi": {
       "version": "9.0.0",
@@ -8311,9 +8317,9 @@
       }
     },
     "node_modules/tiny-svg": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.3.tgz",
-      "integrity": "sha512-u5KGg889pD1W2c9GlLrTnAGzIkAO00/VXZGyzeiGHw+b9er8McLO0SnhxPQQDwDqFO0MrJ825AEsRUoTiDZFuQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.0.tgz",
+      "integrity": "sha512-+u6VomQO7MbI7CQe5q1IwNePpbVKG/HVdUQBmaEpSCdP/QmeyjhrS6WKFsNetXlvf9LWu/f5woRqjMdxBMe/0w=="
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -11716,6 +11722,14 @@
         "object-refs": "^0.3.0",
         "path-intersection": "^2.2.1",
         "tiny-svg": "^2.2.2"
+      },
+      "dependencies": {
+        "tiny-svg": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.4.tgz",
+          "integrity": "sha512-NOi39lBknf4UdDEahNkbEAJnzhu1ZcN2j75IS2vLRmIhsfxdZpTChfLKBcN1ShplVmPIXJAIafk6YY5/Aa80lQ==",
+          "dev": true
+        }
       }
     },
     "didi": {
@@ -16171,9 +16185,9 @@
       }
     },
     "tiny-svg": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.3.tgz",
-      "integrity": "sha512-u5KGg889pD1W2c9GlLrTnAGzIkAO00/VXZGyzeiGHw+b9er8McLO0SnhxPQQDwDqFO0MrJ825AEsRUoTiDZFuQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.0.tgz",
+      "integrity": "sha512-+u6VomQO7MbI7CQe5q1IwNePpbVKG/HVdUQBmaEpSCdP/QmeyjhrS6WKFsNetXlvf9LWu/f5woRqjMdxBMe/0w=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "bpmn.io",
   "license": "MIT",
   "dependencies": {
-    "tiny-svg": "^2.0.0"
+    "tiny-svg": "^3.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
To be consistent with the rest of the `bpmn-js` packages. Otherwise `tiny-svg` is duplicated as there are version 2 and version 3 in my application bundle.